### PR TITLE
Deferred Matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Unlike Appium based clients, [Detox](https://github.com/wix/Detox) is yet to sup
   - [Element](./docs/api/element.md)
   - [Elements](./docs/api/elements.md)
   - [Device](./docs/api/device.md)
+  - [Gesture](./docs/api/gesture.md)
   - [Gestures](./docs/api/gestures.md)
   - [Expect](./docs/api/expect.md)
   - [Utilities](./docs/api/utilities.md)

--- a/__tests__/appium-service/findElement.spec.js
+++ b/__tests__/appium-service/findElement.spec.js
@@ -29,7 +29,7 @@ it("makes a POST request to the 'Find Element' Appium endpoint", async () => {
   expect(requestHelpers.request).toHaveBeenCalledWith({
     method: "POST",
     path: `/session/${sessionId}/element`,
-    payload: matcher
+    payload: matcher.resolve()
   });
 });
 
@@ -48,7 +48,7 @@ it("makes a POST request to the 'Find Element From Element' Appium endpoint when
   expect(requestHelpers.request).toHaveBeenCalledWith({
     method: "POST",
     path: `/session/${sessionId}/element/${ref.ELEMENT}/element`,
-    payload: matcher
+    payload: matcher.resolve()
   });
 });
 
@@ -66,6 +66,6 @@ it("optionally accepts a sessionId", async () => {
   expect(requestHelpers.request).toHaveBeenCalledWith({
     method: "POST",
     path: `/session/${sessionId}/element`,
-    payload: matcher
+    payload: matcher.resolve()
   });
 });

--- a/__tests__/appium-service/findElements.spec.js
+++ b/__tests__/appium-service/findElements.spec.js
@@ -29,7 +29,7 @@ it("makes a POST request to the 'Find Elements' Appium endpoint", async () => {
   expect(requestHelpers.request).toHaveBeenCalledWith({
     method: "POST",
     path: `/session/${sessionId}/elements`,
-    payload: matcher
+    payload: matcher.resolve()
   });
 });
 
@@ -48,7 +48,7 @@ it("makes a POST request to the 'Find Elements From Element' Appium endpoint whe
   expect(requestHelpers.request).toHaveBeenCalledWith({
     method: "POST",
     path: `/session/${sessionId}/element/${ref.ELEMENT}/elements`,
-    payload: matcher
+    payload: matcher.resolve()
   });
 });
 
@@ -66,6 +66,6 @@ it("optionally accepts a sessionId", async () => {
   expect(requestHelpers.request).toHaveBeenCalledWith({
     method: "POST",
     path: `/session/${sessionId}/elements`,
-    payload: matcher
+    payload: matcher.resolve()
   });
 });

--- a/__tests__/element/clearText.spec.js
+++ b/__tests__/element/clearText.spec.js
@@ -49,7 +49,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("input")).clearText();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "input".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/findElement.spec.js
+++ b/__tests__/element/findElement.spec.js
@@ -38,7 +38,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("screen")).findElement(by.label("input"));
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "screen".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/findElements.spec.js
+++ b/__tests__/element/findElements.spec.js
@@ -40,7 +40,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("screen")).findElements(by.label("button"));
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "screen".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/getAttribute.spec.js
+++ b/__tests__/element/getAttribute.spec.js
@@ -40,7 +40,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("box")).getAttribute("name");
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "box".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/getLocation.spec.js
+++ b/__tests__/element/getLocation.spec.js
@@ -55,7 +55,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("box")).getLocation();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "box".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/getSize.spec.js
+++ b/__tests__/element/getSize.spec.js
@@ -38,7 +38,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("box")).getSize();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "box".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/getText.spec.js
+++ b/__tests__/element/getText.spec.js
@@ -38,7 +38,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("box")).getText();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "box".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/getValue.spec.js
+++ b/__tests__/element/getValue.spec.js
@@ -55,7 +55,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("input")).getValue();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "input".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/isDisabled.spec.js
+++ b/__tests__/element/isDisabled.spec.js
@@ -38,7 +38,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("input")).isDisabled();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "input".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/isSelected.spec.js
+++ b/__tests__/element/isSelected.spec.js
@@ -39,7 +39,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("button")).isSelected();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "button".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/longPress.spec.js
+++ b/__tests__/element/longPress.spec.js
@@ -91,7 +91,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("box")).longPress();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "box".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/swipe.spec.js
+++ b/__tests__/element/swipe.spec.js
@@ -106,7 +106,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("list-item")).swipe({ distance: 100, direction: 270 });
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "list-item".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/swipeDown.spec.js
+++ b/__tests__/element/swipeDown.spec.js
@@ -122,7 +122,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("list-item")).swipeDown({ distance: 100 });
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "list-item".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/swipeLeft.spec.js
+++ b/__tests__/element/swipeLeft.spec.js
@@ -154,7 +154,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("list-item")).swipeLeft({ distance: 100 });
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "list-item".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/swipeRight.spec.js
+++ b/__tests__/element/swipeRight.spec.js
@@ -122,7 +122,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("list-item")).swipeRight({ distance: 100 });
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "list-item".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/swipeUp.spec.js
+++ b/__tests__/element/swipeUp.spec.js
@@ -154,7 +154,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("list-item")).swipeUp({ distance: 100 });
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "list-item".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/takeScreenshot.spec.js
+++ b/__tests__/element/takeScreenshot.spec.js
@@ -54,7 +54,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("list-item")).takeScreenshot();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "list-item".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/tap.spec.js
+++ b/__tests__/element/tap.spec.js
@@ -92,7 +92,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("box")).tap();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "box".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/tapBackspaceKey.spec.js
+++ b/__tests__/element/tapBackspaceKey.spec.js
@@ -49,7 +49,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("input")).tapBackspaceKey();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "input".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/tapReturnKey.spec.js
+++ b/__tests__/element/tapReturnKey.spec.js
@@ -49,7 +49,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("input")).tapReturnKey();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "input".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/element/typeText.spec.js
+++ b/__tests__/element/typeText.spec.js
@@ -52,7 +52,7 @@ it("throws an ElementNotFoundError if the element isn't found", async () => {
     await element(by.label("input")).typeText("Hello world!");
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "input".`);
   }
 
   expect(appiumService.findElement).toHaveBeenCalledTimes(1);

--- a/__tests__/elements.spec.js
+++ b/__tests__/elements.spec.js
@@ -34,7 +34,7 @@ it("throws an ElementNotFoundError for Appium request errors", async () => {
     await elements(by.label("list-item"));
   } catch (err) {
     expect(err).toBeInstanceOf(ElementsNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find elements.");
+    expect(err).toHaveProperty("message", `Failed to find elements by label matching "list-item".`);
   }
 });
 

--- a/__tests__/gesture/moveTo.spec.js
+++ b/__tests__/gesture/moveTo.spec.js
@@ -110,6 +110,6 @@ it("throws if the element is not found", async () => {
     await gesture.resolve();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "button".`);
   }
 });

--- a/__tests__/gesture/press.spec.js
+++ b/__tests__/gesture/press.spec.js
@@ -113,6 +113,6 @@ it("throws if the element is not found", async () => {
     await gesture.resolve();
   } catch (err) {
     expect(err).toBeInstanceOf(ElementNotFoundError);
-    expect(err).toHaveProperty("message", "Failed to find element.");
+    expect(err).toHaveProperty("message", `Failed to find element by label matching "button".`);
   }
 });

--- a/__tests__/matchers/css.spec.js
+++ b/__tests__/matchers/css.spec.js
@@ -2,11 +2,21 @@ jest.mock("../../src/worker/stores/sessionStore");
 
 const { setPlatform } = require("../helpers");
 const { NotImplementedError } = require("../../src/worker/errors");
+const Matcher = require("../../src/worker/Matcher");
 const { by } = require("../../");
 
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
+});
+
+it("returns a Matcher instance", () => {
+  const css = ".test";
+  const matcher = by.css(css);
+
+  expect(matcher).toBeInstanceOf(Matcher);
+  expect(matcher.type).toEqual("css");
+  expect(matcher.value).toEqual(css);
 });
 
 describe("Android", () => {
@@ -16,7 +26,7 @@ describe("Android", () => {
     expect.assertions(2);
 
     try {
-      by.css("#text-input");
+      by.css("#text-input").resolve();
     } catch (err) {
       expect(err).toBeInstanceOf(NotImplementedError);
       expect(err).toHaveProperty("message", "Functionality not implemented.");
@@ -31,7 +41,7 @@ describe("iOS", () => {
     expect.assertions(2);
 
     try {
-      by.css("#text-input");
+      by.css("#text-input").resolve();
     } catch (err) {
       expect(err).toBeInstanceOf(NotImplementedError);
       expect(err).toHaveProperty("message", "Functionality not implemented.");
@@ -45,7 +55,7 @@ describe("Web", () => {
   it("supports simple queries", () => {
     const css = "#text-input";
 
-    expect(by.css(css)).toEqual({
+    expect(by.css(css).resolve()).toEqual({
       using: "css selector",
       value: css
     });

--- a/__tests__/matchers/id.spec.js
+++ b/__tests__/matchers/id.spec.js
@@ -2,11 +2,21 @@ jest.mock("../../src/worker/stores/sessionStore");
 
 const { setPlatform } = require("../helpers");
 const { NotImplementedError } = require("../../src/worker/errors");
+const Matcher = require("../../src/worker/Matcher");
 const { by } = require("../../");
 
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
+});
+
+it("returns a Matcher instance", () => {
+  const id = "test";
+  const matcher = by.id(id);
+
+  expect(matcher).toBeInstanceOf(Matcher);
+  expect(matcher.type).toEqual("id");
+  expect(matcher.value).toEqual(id);
 });
 
 describe("Android", () => {
@@ -15,21 +25,21 @@ describe("Android", () => {
   it("supports simple queries", () => {
     const id = "list-item-0";
 
-    expect(by.id(id)).toEqual({
+    expect(by.id(id).resolve()).toEqual({
       using: "id",
       value: id
     });
   });
 
   it("supports regex queries", () => {
-    expect(by.id(/list-item-*/)).toEqual({
+    expect(by.id(/list-item-*/).resolve()).toEqual({
       using: "-android uiautomator",
       value: `new UiSelector().resourceIdMatches("list-item-*")`
     });
   });
 
   it("supports case-insensitive regex queries", () => {
-    expect(by.id(/LIST-ITEM-*/i)).toEqual({
+    expect(by.id(/LIST-ITEM-*/i).resolve()).toEqual({
       using: "-android uiautomator",
       value: `new UiSelector().resourceIdMatches("(?i)LIST-ITEM-*")`
     });
@@ -42,21 +52,21 @@ describe("iOS", () => {
   it("supports simple queries", () => {
     const id = "list-item-0";
 
-    expect(by.id(id)).toEqual({
+    expect(by.id(id).resolve()).toEqual({
       using: "id",
       value: id
     });
   });
 
   it("supports regex queries", () => {
-    expect(by.id(/list-item-*/)).toEqual({
+    expect(by.id(/list-item-*/).resolve()).toEqual({
       using: "-ios predicate string",
       value: `name MATCHES 'list-item-*'`
     });
   });
 
   it("supports case-insensitive regex queries", () => {
-    expect(by.id(/LIST-ITEM-*/i)).toEqual({
+    expect(by.id(/LIST-ITEM-*/i).resolve()).toEqual({
       using: "-ios predicate string",
       value: `name MATCHES[c] 'LIST-ITEM-*'`
     });
@@ -70,7 +80,7 @@ describe("Web", () => {
     expect.assertions(2);
 
     try {
-      by.id("button");
+      by.id("button").resolve();
     } catch (err) {
       expect(err).toBeInstanceOf(NotImplementedError);
       expect(err).toHaveProperty("message", "Functionality not implemented.");

--- a/__tests__/matchers/iosPredicate.spec.js
+++ b/__tests__/matchers/iosPredicate.spec.js
@@ -1,12 +1,22 @@
 jest.mock("../../src/worker/stores/sessionStore");
 
 const { setPlatform } = require("../helpers");
-const { NotImplementedError } = require("../../src/worker/errors");
+const { NotSupportedError } = require("../../src/worker/errors");
+const Matcher = require("../../src/worker/Matcher");
 const { by } = require("../../");
 
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
+});
+
+it("returns a Matcher instance", () => {
+  const predicate = "type = 'XCUIElementTypeTextField'";
+  const matcher = by.iosPredicate(predicate);
+
+  expect(matcher).toBeInstanceOf(Matcher);
+  expect(matcher.type).toEqual("ios predicate");
+  expect(matcher.value).toEqual(predicate);
 });
 
 describe("Android", () => {
@@ -16,10 +26,10 @@ describe("Android", () => {
     expect.assertions(2);
 
     try {
-      by.iosPredicate("type = 'android.widget.EditText'");
+      by.iosPredicate("type = 'android.widget.EditText'").resolve();
     } catch (err) {
-      expect(err).toBeInstanceOf(NotImplementedError);
-      expect(err).toHaveProperty("message", "Functionality not implemented.");
+      expect(err).toBeInstanceOf(NotSupportedError);
+      expect(err).toHaveProperty("message", "Functionality not supported.");
     }
   });
 });
@@ -30,7 +40,7 @@ describe("iOS", () => {
   it("supports simple queries", () => {
     const predicate = "type = 'XCUIElementTypeTextField'";
 
-    expect(by.iosPredicate(predicate)).toEqual({
+    expect(by.iosPredicate(predicate).resolve()).toEqual({
       using: "-ios predicate string",
       value: predicate
     });
@@ -44,10 +54,10 @@ describe("Web", () => {
     expect.assertions(2);
 
     try {
-      by.iosPredicate("type = 'div'");
+      by.iosPredicate("type = 'div'").resolve();
     } catch (err) {
-      expect(err).toBeInstanceOf(NotImplementedError);
-      expect(err).toHaveProperty("message", "Functionality not implemented.");
+      expect(err).toBeInstanceOf(NotSupportedError);
+      expect(err).toHaveProperty("message", "Functionality not supported.");
     }
   });
 });

--- a/__tests__/matchers/label.spec.js
+++ b/__tests__/matchers/label.spec.js
@@ -2,11 +2,21 @@ jest.mock("../../src/worker/stores/sessionStore");
 
 const { setPlatform } = require("../helpers");
 const { NotImplementedError } = require("../../src/worker/errors");
+const Matcher = require("../../src/worker/Matcher");
 const { by } = require("../../");
 
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
+});
+
+it("returns a Matcher instance", () => {
+  const label = "test";
+  const matcher = by.label(label);
+
+  expect(matcher).toBeInstanceOf(Matcher);
+  expect(matcher.type).toEqual("label");
+  expect(matcher.value).toEqual(label);
 });
 
 describe("Android", () => {
@@ -15,21 +25,21 @@ describe("Android", () => {
   it("supports simple queries", () => {
     const label = "list-item-0";
 
-    expect(by.label(label)).toEqual({
+    expect(by.label(label).resolve()).toEqual({
       using: "accessibility id",
       value: label
     });
   });
 
   it("supports regex queries", () => {
-    expect(by.label(/list-item-*/)).toEqual({
+    expect(by.label(/list-item-*/).resolve()).toEqual({
       using: "-android uiautomator",
       value: `new UiSelector().descriptionMatches("list-item-*")`
     });
   });
 
   it("supports case-insensitive regex queries", () => {
-    expect(by.label(/LIST-ITEM-*/i)).toEqual({
+    expect(by.label(/LIST-ITEM-*/i).resolve()).toEqual({
       using: "-android uiautomator",
       value: `new UiSelector().descriptionMatches("(?i)LIST-ITEM-*")`
     });
@@ -42,21 +52,21 @@ describe("iOS", () => {
   it("supports simple queries", () => {
     const label = "list-item-0";
 
-    expect(by.label(label)).toEqual({
+    expect(by.label(label).resolve()).toEqual({
       using: "accessibility id",
       value: label
     });
   });
 
   it("supports regex queries", () => {
-    expect(by.label(/list-item-*/)).toEqual({
+    expect(by.label(/list-item-*/).resolve()).toEqual({
       using: "-ios predicate string",
       value: `name MATCHES 'list-item-*'`
     });
   });
 
   it("supports case-insensitive regex queries", () => {
-    expect(by.label(/LIST-ITEM-*/i)).toEqual({
+    expect(by.label(/LIST-ITEM-*/i).resolve()).toEqual({
       using: "-ios predicate string",
       value: `name MATCHES[c] 'LIST-ITEM-*'`
     });
@@ -70,7 +80,7 @@ describe("Web", () => {
     expect.assertions(2);
 
     try {
-      by.label("button");
+      by.label("button").resolve();
     } catch (err) {
       expect(err).toBeInstanceOf(NotImplementedError);
       expect(err).toHaveProperty("message", "Functionality not implemented.");

--- a/__tests__/matchers/text.spec.js
+++ b/__tests__/matchers/text.spec.js
@@ -2,6 +2,7 @@ jest.mock("../../src/worker/stores/sessionStore");
 
 const { setPlatform } = require("../helpers");
 const { NotImplementedError } = require("../../src/worker/errors");
+const Matcher = require("../../src/worker/Matcher");
 const { by } = require("../../");
 
 afterEach(() => {
@@ -9,29 +10,38 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+it("returns a Matcher instance", () => {
+  const text = "Hello World!";
+  const matcher = by.text(text);
+
+  expect(matcher).toBeInstanceOf(Matcher);
+  expect(matcher.type).toEqual("text");
+  expect(matcher.value).toEqual(text);
+});
+
 describe("Android", () => {
   beforeEach(() => setPlatform("Android"));
 
   it("supports simple queries", () => {
-    const label = "list-item-0";
+    const text = "hello";
 
-    expect(by.text(label)).toEqual({
+    expect(by.text(text).resolve()).toEqual({
       using: `-android uiautomator`,
-      value: `new UiSelector().text("${label}")`
+      value: `new UiSelector().text("${text}")`
     });
   });
 
   it("supports regex queries", () => {
-    expect(by.text(/list-item-*/)).toEqual({
+    expect(by.text(/hello*/).resolve()).toEqual({
       using: "-android uiautomator",
-      value: `new UiSelector().textMatches("list-item-*")`
+      value: `new UiSelector().textMatches("hello*")`
     });
   });
 
   it("supports case-insensitive regex queries", () => {
-    expect(by.text(/LIST-ITEM-*/i)).toEqual({
+    expect(by.text(/HELLO*/i).resolve()).toEqual({
       using: "-android uiautomator",
-      value: `new UiSelector().textMatches("(?i)LIST-ITEM-*")`
+      value: `new UiSelector().textMatches("(?i)HELLO*")`
     });
   });
 });
@@ -40,25 +50,25 @@ describe("iOS", () => {
   beforeEach(() => setPlatform("iOS"));
 
   it("supports simple queries", () => {
-    const label = "list-item-0";
+    const text = "Hello World!";
 
-    expect(by.text(label)).toEqual({
+    expect(by.text(text).resolve()).toEqual({
       using: "-ios predicate string",
-      value: `label = '${label}'`
+      value: `label = '${text}'`
     });
   });
 
   it("supports regex queries", () => {
-    expect(by.text(/list-item-*/)).toEqual({
+    expect(by.text(/hello*/).resolve()).toEqual({
       using: "-ios predicate string",
-      value: `label MATCHES 'list-item-*'`
+      value: `label MATCHES 'hello*'`
     });
   });
 
   it("supports case-insensitive regex queries", () => {
-    expect(by.text(/LIST-ITEM-*/i)).toEqual({
+    expect(by.text(/HELLO*/i).resolve()).toEqual({
       using: "-ios predicate string",
-      value: `label MATCHES[c] 'LIST-ITEM-*'`
+      value: `label MATCHES[c] 'HELLO*'`
     });
   });
 });
@@ -70,7 +80,7 @@ describe("Web", () => {
     expect.assertions(2);
 
     try {
-      by.text("Hello World!");
+      by.text("Hello World!").resolve();
     } catch (err) {
       expect(err).toBeInstanceOf(NotImplementedError);
       expect(err).toHaveProperty("message", "Functionality not implemented.");

--- a/__tests__/matchers/type.spec.js
+++ b/__tests__/matchers/type.spec.js
@@ -1,11 +1,21 @@
 jest.mock("../../src/worker/stores/sessionStore");
 
 const { setPlatform } = require("../helpers");
+const Matcher = require("../../src/worker/Matcher");
 const { by } = require("../../");
 
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
+});
+
+it("returns a Matcher instance", () => {
+  const type = "XCUIElementTypeTextField";
+  const matcher = by.type(type);
+
+  expect(matcher).toBeInstanceOf(Matcher);
+  expect(matcher.type).toEqual("type");
+  expect(matcher.value).toEqual(type);
 });
 
 describe("Android", () => {
@@ -14,7 +24,7 @@ describe("Android", () => {
   it("supports simple queries", () => {
     const type = "android.widget.EditText";
 
-    expect(by.type(type)).toEqual({
+    expect(by.type(type).resolve()).toEqual({
       using: "class name",
       value: type
     });
@@ -27,7 +37,7 @@ describe("iOS", () => {
   it("supports simple queries", () => {
     const type = "XCUIElementTypeTextField";
 
-    expect(by.type(type)).toEqual({
+    expect(by.type(type).resolve()).toEqual({
       using: "class name",
       value: type
     });

--- a/__tests__/matchers/uiAutomator.spec.js
+++ b/__tests__/matchers/uiAutomator.spec.js
@@ -1,12 +1,22 @@
 jest.mock("../../src/worker/stores/sessionStore");
 
 const { setPlatform } = require("../helpers");
-const { NotImplementedError } = require("../../src/worker/errors");
+const { NotSupportedError } = require("../../src/worker/errors");
+const Matcher = require("../../src/worker/Matcher");
 const { by } = require("../../");
 
 afterEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
+});
+
+it("returns a Matcher instance", () => {
+  const selector = "new UiSelector().className(\"android.widget.EditText\")";
+  const matcher = by.uiAutomator(selector);
+
+  expect(matcher).toBeInstanceOf(Matcher);
+  expect(matcher.type).toEqual("ui automator");
+  expect(matcher.value).toEqual(selector);
 });
 
 describe("Android", () => {
@@ -15,7 +25,7 @@ describe("Android", () => {
   it("supports simple queries", () => {
     const selector = `new UiSelector().className("android.widget.EditText")`;
 
-    expect(by.uiAutomator(selector)).toEqual({
+    expect(by.uiAutomator(selector).resolve()).toEqual({
       using: "-android uiautomator",
       value: selector
     });
@@ -29,10 +39,10 @@ describe("iOS", () => {
     expect.assertions(2);
 
     try {
-      by.uiAutomator(`new UiSelector().className("XCUIElementTypeTextField")`);
+      by.uiAutomator(`new UiSelector().className("XCUIElementTypeTextField")`).resolve();
     } catch (err) {
-      expect(err).toBeInstanceOf(NotImplementedError);
-      expect(err).toHaveProperty("message", "Functionality not implemented.");
+      expect(err).toBeInstanceOf(NotSupportedError);
+      expect(err).toHaveProperty("message", "Functionality not supported.");
     }
   });
 });
@@ -44,10 +54,10 @@ describe("Web", () => {
     expect.assertions(2);
 
     try {
-      by.uiAutomator(`new UiSelector().className("input")`);
+      by.uiAutomator(`new UiSelector().className("input")`).resolve();
     } catch (err) {
-      expect(err).toBeInstanceOf(NotImplementedError);
-      expect(err).toHaveProperty("message", "Functionality not implemented.");
+      expect(err).toBeInstanceOf(NotSupportedError);
+      expect(err).toHaveProperty("message", "Functionality not supported.");
     }
   });
 });

--- a/examples/native-demo-app/tests/form-screen.e2e.js
+++ b/examples/native-demo-app/tests/form-screen.e2e.js
@@ -1,10 +1,9 @@
-const { by, element, device, gestures, expect } = require("../../../index");
+const { by, element, device, expect } = require("../../../index");
 
 describe("Form Screen", () => {
   before(async () => {
     await element(by.label("menu-screen")).waitToBeVisible();
     await element(by.label("list-item-form-screen")).tap();
-    await element(by.label("menu-screen")).waitToBeInvisible();
     await element(by.label("form-screen")).waitToBeVisible();
   });
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
       .then((refs) => refs.map((ref) => new Element({ value: Promise.resolve({ ref, matcher: null }) })))
       .catch((err) => {
         if (isInstanceOf(err, AppiumError)) {
-          throw new ElementsNotFoundError("Failed to find elements.", matcher);
+          throw new ElementsNotFoundError(matcher);
         }
 
         throw err;

--- a/src/worker/Element.js
+++ b/src/worker/Element.js
@@ -12,9 +12,7 @@ const getCurrentValue = (elementValue) => {
       if (isInstanceOf(err, ElementNotFoundError) && err.matcher) {
         return appiumService.findElement({ matcher: err.matcher })
           .then((ref) => ({ ref, matcher: err.matcher }))
-          .catch(() => {
-            throw new ElementNotFoundError("Failed to find element.", err.matcher);
-          });
+          .catch(() => { throw new ElementNotFoundError(err.matcher); });
       }
 
       throw err;
@@ -23,9 +21,7 @@ const getCurrentValue = (elementValue) => {
       if (isNull(value.ref) && value.matcher) {
         return appiumService.findElement({ matcher: value.matcher })
           .then((ref) => ({ ref, matcher: value.matcher }))
-          .catch(() => {
-            throw new ElementNotFoundError("Failed to find element.", value.matcher);
-          });
+          .catch(() => { throw new ElementNotFoundError(value.matcher); });
       }
 
       return value;

--- a/src/worker/Matcher.js
+++ b/src/worker/Matcher.js
@@ -4,14 +4,6 @@ class Matcher {
     this.value = value;
     this.resolve = resolve;
   }
-
-  getLocator() {
-    try {
-      return this.resolve();
-    } catch(e) {
-      return null;
-    }
-  }
 }
 
 module.exports = Matcher;

--- a/src/worker/Matcher.js
+++ b/src/worker/Matcher.js
@@ -1,0 +1,17 @@
+class Matcher {
+  constructor({ type, value, resolve }) {
+    this.type = type;
+    this.value = value;
+    this.resolve = resolve;
+  }
+
+  getLocator() {
+    try {
+      return this.resolve();
+    } catch(e) {
+      return null;
+    }
+  }
+}
+
+module.exports = Matcher;

--- a/src/worker/errors.js
+++ b/src/worker/errors.js
@@ -1,22 +1,22 @@
 const { last } = require("../utils");
 
 class ElementNotFoundError extends Error {
-  constructor(message, matcher) {
-    super(message);
+  constructor(matcher) {
+    super(`Failed to find element by ${matcher.type} matching "${matcher.value}"`);
 
     Error.captureStackTrace(this, ElementNotFoundError);
     this.name = this.constructor.name;
-    this.matcher = matcher;
+    this.locator = matcher.getLocator();
   }
 }
 
 class ElementsNotFoundError extends Error {
-  constructor(message, matcher) {
-    super(message);
+  constructor(matcher) {
+    super(`Failed to find elements by ${matcher.type} matching "${matcher.value}"`);
 
     Error.captureStackTrace(this, ElementsNotFoundError);
     this.name = this.constructor.name;
-    this.matcher = matcher;
+    this.locator = matcher.getLocator();
   }
 }
 

--- a/src/worker/errors.js
+++ b/src/worker/errors.js
@@ -2,21 +2,21 @@ const { last } = require("../utils");
 
 class ElementNotFoundError extends Error {
   constructor(matcher) {
-    super(`Failed to find element by ${matcher.type} matching "${matcher.value}"`);
+    super(`Failed to find element by ${matcher.type} matching "${matcher.value}".`);
 
     Error.captureStackTrace(this, ElementNotFoundError);
     this.name = this.constructor.name;
-    this.locator = matcher.getLocator();
+    this.matcher = matcher;
   }
 }
 
 class ElementsNotFoundError extends Error {
   constructor(matcher) {
-    super(`Failed to find elements by ${matcher.type} matching "${matcher.value}"`);
+    super(`Failed to find elements by ${matcher.type} matching "${matcher.value}".`);
 
     Error.captureStackTrace(this, ElementsNotFoundError);
     this.name = this.constructor.name;
-    this.locator = matcher.getLocator();
+    this.matcher = matcher;
   }
 }
 

--- a/src/worker/matchers.js
+++ b/src/worker/matchers.js
@@ -1,5 +1,5 @@
 const { platform, isPlatform, isRegex } = require("../utils");
-const { NotImplementedError } = require("./errors");
+const { NotImplementedError, NotSupportedError } = require("./errors");
 const Matcher = require("./Matcher");
 const getNativeRegex = require("./helpers/getNativeRegex");
 
@@ -129,7 +129,7 @@ const createIosPredicateMatcher = (predicate) => {
         };
       }
 
-      throw new NotImplementedError();
+      throw new NotSupportedError();
     }
   });
 };
@@ -146,7 +146,7 @@ const createUiAutomatorMatcher = (selector) => {
         };
       }
 
-      throw new NotImplementedError();
+      throw new NotSupportedError();
     }
   });
 };

--- a/src/worker/matchers.js
+++ b/src/worker/matchers.js
@@ -1,135 +1,179 @@
 const { platform, isPlatform, isRegex } = require("../utils");
 const { NotImplementedError } = require("./errors");
+const Matcher = require("./Matcher");
 const getNativeRegex = require("./helpers/getNativeRegex");
 
-const getByIdMatcher = (id) => {
-  if (isPlatform("Web")) {
-    throw new NotImplementedError();
-  }
+const createIdMatcher = (id) => {
+  return new Matcher({
+    type: "id",
+    value: id,
+    resolve: () => {
+      if (isPlatform("Web")) {
+        throw new NotImplementedError();
+      }
 
-  if (isRegex(id)) {
-    const regex = getNativeRegex(id);
+      if (isRegex(id)) {
+        const regex = getNativeRegex(id);
 
-    return platform.select({
-      ios: () => ({
-        using: "-ios predicate string",
-        value: `name MATCHES${regex.modifiers} '${regex.pattern}'`
-      }),
-      android: () => ({
-        using: "-android uiautomator",
-        value: `new UiSelector().resourceIdMatches("${regex.modifiers}${regex.pattern}")`
-      })
-    });
-  }
+        return platform.select({
+          ios: () => ({
+            using: "-ios predicate string",
+            value: `name MATCHES${regex.modifiers} '${regex.pattern}'`
+          }),
+          android: () => ({
+            using: "-android uiautomator",
+            value: `new UiSelector().resourceIdMatches("${regex.modifiers}${regex.pattern}")`
+          })
+        });
+      }
 
-  return {
-    using: "id",
-    value: id
-  };
+      return {
+        using: "id",
+        value: id
+      };
+    }
+  });
 };
 
-const getByAccessibilityLabelMatcher = (accessibilityLabel) => {
-  if (isPlatform("Web")) {
-    throw new NotImplementedError();
-  }
+const createLabelMatcher = (label) => {
+  return new Matcher({
+    type: "label",
+    value: label,
+    resolve: () => {
+      if (isPlatform("Web")) {
+        throw new NotImplementedError();
+      }
 
-  if (isRegex(accessibilityLabel)) {
-    const regex = getNativeRegex(accessibilityLabel);
+      if (isRegex(label)) {
+        const regex = getNativeRegex(label);
 
-    return platform.select({
-      ios: () => ({
-        using: "-ios predicate string",
-        value: `name MATCHES${regex.modifiers} '${regex.pattern}'`
-      }),
-      android: () => ({
-        using: "-android uiautomator",
-        value: `new UiSelector().descriptionMatches("${regex.modifiers}${regex.pattern}")`
-      })
-    });
-  }
+        return platform.select({
+          ios: () => ({
+            using: "-ios predicate string",
+            value: `name MATCHES${regex.modifiers} '${regex.pattern}'`
+          }),
+          android: () => ({
+            using: "-android uiautomator",
+            value: `new UiSelector().descriptionMatches("${regex.modifiers}${regex.pattern}")`
+          })
+        });
+      }
 
-  return {
-    using: "accessibility id",
-    value: accessibilityLabel
-  };
+      return {
+        using: "accessibility id",
+        value: label
+      };
+    }
+  });
 };
 
-const getByTextMatcher = (text) => {
-  if (isPlatform("Web")) {
-    throw new NotImplementedError();
-  }
+const createTextMatcher = (text) => {
+  return new Matcher({
+    type: "text",
+    value: text,
+    resolve: () => {
+      if (isPlatform("Web")) {
+        throw new NotImplementedError();
+      }
 
-  if (isRegex(text)) {
-    const regex = getNativeRegex(text);
+      if (isRegex(text)) {
+        const regex = getNativeRegex(text);
 
-    return platform.select({
-      ios: () => ({
-        using: "-ios predicate string",
-        value: `label MATCHES${regex.modifiers} '${regex.pattern}'`
-      }),
-      android: () => ({
-        using: "-android uiautomator",
-        value: `new UiSelector().textMatches("${regex.modifiers}${regex.pattern}")`
-      })
-    });
-  }
+        return platform.select({
+          ios: () => ({
+            using: "-ios predicate string",
+            value: `label MATCHES${regex.modifiers} '${regex.pattern}'`
+          }),
+          android: () => ({
+            using: "-android uiautomator",
+            value: `new UiSelector().textMatches("${regex.modifiers}${regex.pattern}")`
+          })
+        });
+      }
 
-  return platform.select({
-    ios: () => ({
-      using: "-ios predicate string",
-      value: `label = '${text}'`
-    }),
-    android: () => ({
-      using: "-android uiautomator",
-      value: `new UiSelector().text("${text}")`
+      return platform.select({
+        ios: () => ({
+          using: "-ios predicate string",
+          value: `label = '${text}'`
+        }),
+        android: () => ({
+          using: "-android uiautomator",
+          value: `new UiSelector().text("${text}")`
+        })
+      });
+    }
+  });
+};
+
+// TODO: Investigate Web context support.
+const createTypeMatcher = (type) => {
+  return new Matcher({
+    type: "type",
+    value: type,
+    resolve: () => ({
+      using: "class name",
+      value: type
     })
   });
 };
 
-const getByTypeMatcher = (type) => ({
-  using: "class name",
-  value: type
-});
+const createIosPredicateMatcher = (predicate) => {
+  return new Matcher({
+    type: "ios predicate",
+    value: predicate,
+    resolve: () => {
+      if (isPlatform("iOS")) {
+        return {
+          using: "-ios predicate string",
+          value: predicate
+        };
+      }
 
-const getIosPredicateMatcher = (predicate) => {
-  return platform.select({
-    ios: () => ({
-      using: "-ios predicate string",
-      value: predicate
-    }),
-    android: () => { throw new NotImplementedError(); },
-    web: () => { throw new NotImplementedError(); }
+      throw new NotImplementedError();
+    }
   });
 };
 
-const getUiAutomatorMatcher = (selector) => {
-  return platform.select({
-    ios: () => { throw new NotImplementedError(); },
-    android: () => ({
-      using: "-android uiautomator",
-      value: selector
-    }),
-    web: () => { throw new NotImplementedError(); }
+const createUiAutomatorMatcher = (selector) => {
+  return new Matcher({
+    type: "ui automator",
+    value: selector,
+    resolve: () => {
+      if (isPlatform("Android")) {
+        return {
+          using: "-android uiautomator",
+          value: selector
+        };
+      }
+
+      throw new NotImplementedError();
+    }
   });
 };
 
-// Note: Only works in a Web context.
-const getByCssMatcher = (css) => {
-  return platform.select({
-    native: () => { throw new NotImplementedError(); },
-    web: () => ({
-      using: "css selector",
-      value: css
-    })
+const createCssMatcher = (css) => {
+  return new Matcher({
+    type: "css",
+    value: css,
+    resolve: () => {
+      if (isPlatform("Web")) {
+        return {
+          using: "css selector",
+          value: css
+        };
+      }
+
+      throw new NotImplementedError();
+    }
   });
 };
 
 module.exports = {
-  id: getByIdMatcher,
-  label: getByAccessibilityLabelMatcher,
-  text: getByTextMatcher,
-  type: getByTypeMatcher,
-  iosPredicate: getIosPredicateMatcher,
-  uiAutomator: getUiAutomatorMatcher,
-  css: getByCssMatcher
+  id: createIdMatcher,
+  label: createLabelMatcher,
+  text: createTextMatcher,
+  type: createTypeMatcher,
+  iosPredicate: createIosPredicateMatcher,
+  uiAutomator: createUiAutomatorMatcher,
+  css: createCssMatcher
 };

--- a/src/worker/services/appiumService.js
+++ b/src/worker/services/appiumService.js
@@ -2,6 +2,7 @@ const { sessionStore } = require("../stores/sessionStore");
 const { AppiumError } = require("../errors");
 const { NotImplementedError, NotSupportedError } = require("../errors");
 const gestures = require("../gestures");
+const matchers = require("../matchers");
 const { platform, isInstanceOf, isString, toBoolean, toNumber } = require("../../utils");
 const { transformBounds } = require("../attributeTransforms");
 const { request } = require("./request");
@@ -300,37 +301,37 @@ function createAppiumService(sessionStore) {
     });
   };
 
-  // ({ sessionId: String?, matcher: AppiumMatcher, element?: AppiumElement }) => Promise<AppiumElement>.
+  // ({ sessionId: String?, matcher: Matcher, element?: AppiumElement }) => Promise<AppiumElement>.
   const findElement = ({ sessionId = sessionStore.getSessionId(), matcher, element }) => {
     if (element) {
       return request({
         method: "POST",
         path: `/session/${sessionId}/element/${element.ELEMENT}/element`,
-        payload: matcher
+        payload: matcher.resolve()
       });
     }
 
     return request({
       method: "POST",
       path: `/session/${sessionId}/element`,
-      payload: matcher
+      payload: matcher.resolve()
     });
   };
 
-  // ({ sessionId: String?, matcher: AppiumMatcher, element?: AppiumElement }) => Promise<Array<AppiumElement>>.
+  // ({ sessionId: String?, matcher: Matcher, element?: AppiumElement }) => Promise<Array<AppiumElement>>.
   const findElements = ({ sessionId = sessionStore.getSessionId(), matcher, element }) => {
     if (element) {
       return request({
         method: "POST",
         path: `/session/${sessionId}/element/${element.ELEMENT}/elements`,
-        payload: matcher
+        payload: matcher.resolve()
       });
     }
 
     return request({
       method: "POST",
       path: `/session/${sessionId}/elements`,
-      payload: matcher
+      payload: matcher.resolve()
     });
   };
 
@@ -465,7 +466,7 @@ function createAppiumService(sessionStore) {
     });
   };
 
-  // ({ sessionId: String?, matcher: AppiumMatcher })
+  // ({ sessionId: String?, matcher: Matcher })
   const getElementExists = ({ sessionId = sessionStore.getSessionId(), matcher }) => {
     return findElement({ sessionId, matcher })
       .then(() => true)
@@ -503,10 +504,7 @@ function createAppiumService(sessionStore) {
                   return text;
                 }
 
-                const matcher = {
-                  using: "-ios predicate string",
-                  value: `type == "XCUIElementTypeStaticText"`
-                };
+                const matcher = matchers.iosPredicate(`type == "XCUIElementTypeStaticText"`);
 
                 return findElements({ sessionId, element, matcher })
                   .then((refs) => {
@@ -525,10 +523,7 @@ function createAppiumService(sessionStore) {
               return getElementTextAttribute({ sessionId, element });
             }
 
-            const matcher = {
-              using: "class name",
-              value: "android.widget.TextView"
-            };
+            const matcher = matchers.type("android.widget.TextView");
 
             return findElements({ sessionId, element, matcher })
               .then((refs) => {


### PR DESCRIPTION
### This PR Includes

- Added 'Gesture' link to README.
- Modified matchers (e.g. `by.label`) to be instances with a resolve method.
- Improved find errors using matcher types and values instead of transformed locator strategies.
- Matchers can be defined without throwing until used.